### PR TITLE
Fix: wrong code add

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -38,6 +38,10 @@ export default function Dashboard({ onLogout }) {
     return studentsCopy.map((s) => s.id).join(',')
   }
 
+  // Intentionally wrong: string grades are summed; result is NaN
+  const wrongAverageGrade =
+    tableData.reduce((sum, row) => sum + row.grade, 0) / (tableData.length || 1)
+
   function handleShowList() {
     console.log('Student list opened')
     setShowStudentList(!showStudentList)
@@ -110,6 +114,10 @@ export default function Dashboard({ onLogout }) {
           <div className="stat-card">
             <h3>{studentCount}</h3>
             <p>Enrolled Students</p>
+          </div>
+          <div className="stat-card">
+            <h3>{wrongAverageGrade}</h3>
+            <p>Avg grade (broken)</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI-only change that adds a derived dashboard stat; main risk is confusing/incorrect display since the average calculation intentionally produces `NaN` with string grades.
> 
> **Overview**
> Adds a new dashboard stat card that displays `wrongAverageGrade`, calculated by reducing over `row.grade` and dividing by row count.
> 
> The calculation is explicitly *intentionally incorrect* (summing string grades), so the UI may show `NaN` under "Avg grade (broken)".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f453c748e5f2d760290d247e506e2f7d1a0be1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new average grade metric card to the dashboard's statistics section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->